### PR TITLE
Missing @Inject annotation

### DIFF
--- a/src/main/java/de/egladil/web/checklistenserver/config/ConfigService.java
+++ b/src/main/java/de/egladil/web/checklistenserver/config/ConfigService.java
@@ -5,6 +5,7 @@
 package de.egladil.web.checklistenserver.config;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -14,15 +15,19 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class ConfigService {
 
+	@Inject
 	@ConfigProperty(name = "block.on.missing.origin.referer", defaultValue = "false")
 	boolean blockOnMissingOriginReferer;
 
+	@Inject
 	@ConfigProperty(name = "target.origin")
 	String targetOrigin;
 
+	@Inject
 	@ConfigProperty(name = "stage")
 	String stage;
 
+	@Inject
 	@ConfigProperty(name = "allowedOrigin", defaultValue = "https://opa-wetterwachs.de")
 	String allowedOrigin;
 

--- a/src/main/java/de/egladil/web/checklistenserver/config/EinkaufslisteTemplate.java
+++ b/src/main/java/de/egladil/web/checklistenserver/config/EinkaufslisteTemplate.java
@@ -6,6 +6,7 @@
 package de.egladil.web.checklistenserver.config;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -17,6 +18,7 @@ public class EinkaufslisteTemplate extends AbstractListeTemplate {
 
 	private static final String SUFFIX_FILENAME = "_einkaufsliste.txt";
 
+	@Inject
 	@ConfigProperty(name = "dir.einkaufslisten")
 	String pathDirEinkaufslisten;
 

--- a/src/main/java/de/egladil/web/checklistenserver/config/PacklisteTemplate.java
+++ b/src/main/java/de/egladil/web/checklistenserver/config/PacklisteTemplate.java
@@ -6,6 +6,7 @@
 package de.egladil.web.checklistenserver.config;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
@@ -17,6 +18,7 @@ public class PacklisteTemplate extends AbstractListeTemplate {
 
 	private static final String SUFFIX_FILENAME = "_packliste.txt";
 
+	@Inject
 	@ConfigProperty(name = "dir.packlisten")
 	String pathDirPacklisten;
 

--- a/src/main/java/de/egladil/web/checklistenserver/endpoints/ChecklistenSessionResource.java
+++ b/src/main/java/de/egladil/web/checklistenserver/endpoints/ChecklistenSessionResource.java
@@ -44,15 +44,19 @@ public class ChecklistenSessionResource {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ChecklistenSessionResource.class);
 
+	@Inject
 	@ConfigProperty(name = "auth-app.url")
 	String authAppUrl;
 
+	@Inject
 	@ConfigProperty(name = "auth.redirect-url.login")
 	String loginRedirectUrl;
 
+	@Inject
 	@ConfigProperty(name = "stage")
 	String stage;
 
+	@Inject
 	@ConfigProperty(name = "auth.redirect-url.signup")
 	String signupRedirectUrl;
 

--- a/src/main/java/de/egladil/web/checklistenserver/endpoints/HeartbeatResource.java
+++ b/src/main/java/de/egladil/web/checklistenserver/endpoints/HeartbeatResource.java
@@ -35,6 +35,7 @@ public class HeartbeatResource {
 
 	private static final Logger LOG = LoggerFactory.getLogger(HeartbeatResource.class);
 
+	@Inject
 	@ConfigProperty(name = "heartbeat.id")
 	String expectedHeartbeatId;
 

--- a/src/main/java/de/egladil/web/checklistenserver/endpoints/LogResource.java
+++ b/src/main/java/de/egladil/web/checklistenserver/endpoints/LogResource.java
@@ -5,6 +5,7 @@
 package de.egladil.web.checklistenserver.endpoints;
 
 import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -30,6 +31,7 @@ public class LogResource {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LogResource.class);
 
+	@Inject
 	@ConfigProperty(name = "auth.client-id")
 	String clientId;
 

--- a/src/main/java/de/egladil/web/checklistenserver/endpoints/VersionResource.java
+++ b/src/main/java/de/egladil/web/checklistenserver/endpoints/VersionResource.java
@@ -5,6 +5,7 @@
 package de.egladil.web.checklistenserver.endpoints;
 
 import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -24,6 +25,7 @@ import de.egladil.web.commons_validation.payload.ResponsePayload;
 @Produces(MediaType.APPLICATION_JSON)
 public class VersionResource {
 
+	@Inject
 	@ConfigProperty(name = "quarkus.application.version")
 	String version;
 

--- a/src/main/java/de/egladil/web/checklistenserver/service/ClientAccessTokenService.java
+++ b/src/main/java/de/egladil/web/checklistenserver/service/ClientAccessTokenService.java
@@ -34,9 +34,11 @@ public class ClientAccessTokenService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClientAccessTokenService.class);
 
+	@Inject
 	@ConfigProperty(name = "auth.client-id")
 	String clientId;
 
+	@Inject
 	@ConfigProperty(name = "auth.client-secret")
 	String clientSecret;
 

--- a/src/main/java/de/egladil/web/checklistenserver/service/TokenExchangeService.java
+++ b/src/main/java/de/egladil/web/checklistenserver/service/TokenExchangeService.java
@@ -35,9 +35,11 @@ public class TokenExchangeService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TokenExchangeService.class);
 
+	@Inject
 	@ConfigProperty(name = "auth.client-id")
 	String clientId;
 
+	@Inject
 	@ConfigProperty(name = "auth.client-secret")
 	String clientSecret;
 


### PR DESCRIPTION
When using the `@ConfigProperty` annotation from Microprofile on a field, the field must be annotated with `@Inject`.